### PR TITLE
correct code for refunding the credit card

### DIFF
--- a/lib/activemerchant_paybox_direct_plus.rb
+++ b/lib/activemerchant_paybox_direct_plus.rb
@@ -16,7 +16,8 @@ module ActiveMerchant #:nodoc:
         :subscriber_authorization => '00051',
         :subscriber_capture => '00052',
         :subscriber_purchase => '00053',
-        :subscriber_credit => '00014',
+        :subscriber_credit => '00054',
+        :subscriber_refund => '00014',
         :subscriber_void => '00055',
         :subscriber_create => '00056',
         :subscriber_update => '00057',
@@ -118,6 +119,14 @@ module ActiveMerchant #:nodoc:
         add_reference(post, identification)
         add_user_reference(post, options)
         commit('subscriber_credit', money, post)
+      end
+
+      def refund(money, authorization, options = {})
+        post = {}
+        add_invoice(post, options)
+        add_reference(post, authorization)
+        add_user_reference(post, options)
+        commit('subscriber_refund', money, post)
       end
 
       def create_payment_profile(money, creditcard, options = {})

--- a/test/remote/gateways/remote_paybox_direct_plus_test.rb
+++ b/test/remote/gateways/remote_paybox_direct_plus_test.rb
@@ -50,7 +50,7 @@ class RemotePayboxDirectPlusTest < Test::Unit::TestCase
     assert_equal 'The transaction was approved', success.message
   end
 
-  def test_create_profile_capture_and_credit
+  def test_create_profile_capture_and_refund
     assert response = @gateway.create_payment_profile(@amount, @credit_card, @options)
     assert_success response
     
@@ -60,9 +60,9 @@ class RemotePayboxDirectPlusTest < Test::Unit::TestCase
     assert capture = @gateway.capture(@amount, response.params["authorization"], @options)
     assert_success capture
     
-    assert credit = @gateway.credit(@amount, capture.params["authorization"], @options)
-    assert_equal 'The transaction was approved', credit.message
-    assert_success credit
+    assert refund = @gateway.refund(@amount, capture.params["authorization"], @options)
+    assert_equal 'The transaction was approved', refund.message
+    assert_success refund
   end
   
   def test_failed_capture


### PR DESCRIPTION
Changed refunded type code from 00054 to 00014 following a conversation
with Paybox tech support.
